### PR TITLE
Harden DOM scanner startup

### DIFF
--- a/extension/src/background/api-client.js
+++ b/extension/src/background/api-client.js
@@ -30,6 +30,11 @@ export const API_ERROR_CODES = {
     UNKNOWN: 'UNKNOWN'
 };
 
+function hasHeader(headers, name) {
+    const wanted = name.toLowerCase();
+    return Object.keys(headers || {}).some(key => key.toLowerCase() === wanted);
+}
+
 /**
  * Request queue for managing concurrent requests
  */
@@ -215,7 +220,7 @@ export class XAPIClient {
      * Set API headers from captured request
      */
     setHeaders(headers) {
-        if (headers && (headers.authorization || headers['authorization'])) {
+        if (hasHeader(headers, 'authorization') && hasHeader(headers, 'x-csrf-token')) {
             this.headers = { ...headers };
             console.log('✅ API headers configured');
             return true;

--- a/extension/src/background/service-worker.js
+++ b/extension/src/background/service-worker.js
@@ -263,6 +263,10 @@ async function handleFetchUserInfo({ screenName, csrfToken }) {
         if (error.code === API_ERROR_CODES.NOT_FOUND) {
             cacheNotFound(screenName);
         }
+
+        if (error.code === API_ERROR_CODES.UNAUTHORIZED) {
+            await headersStorage.clear();
+        }
         
         // Return specific error information
         return {
@@ -293,6 +297,10 @@ async function handleFetchHovercardInfo({ screenName, csrfToken }) {
 
         return { success: true, data, source: 'api' };
     } catch (error) {
+        if (error.code === API_ERROR_CODES.UNAUTHORIZED) {
+            await headersStorage.clear();
+        }
+
         return {
             success: false,
             error: error.message,

--- a/extension/src/content/content-script.js
+++ b/extension/src/content/content-script.js
@@ -246,6 +246,21 @@ async function initialize() {
             blockedTags = new Set(blockedTagsResponse.data);
         }
 
+        let domObserverStarted = false;
+        const startDomObservation = () => {
+            if (domObserverStarted || !document.body) return;
+            domObserverStarted = true;
+            createMemoizedFunctions();
+            startObserver(memoizedIsEnabledFn, memoizedProcessElementSafe, memoizedScanPageFn, debug);
+        };
+
+        // Start core DOM processing before optional UI setup. This keeps badge
+        // injection working even if theme/sidebar setup hits a page-specific edge.
+        startDomObservation();
+        if (!domObserverStarted) {
+            document.addEventListener('DOMContentLoaded', startDomObservation, { once: true });
+        }
+
         // Inject styles
         injectStyles();
 
@@ -253,19 +268,7 @@ async function initialize() {
         detectAndApplyTheme(debug);
         startThemeObserver();
 
-        // Create memoized functions once (not on every call)
-        createMemoizedFunctions();
-        
-        // Start DOM observation when ready
-        if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', () => {
-                startObserver(memoizedIsEnabledFn, memoizedProcessElementSafe, memoizedScanPageFn, debug);
-                injectSidebarLink(settings, debug, blockedCountries, blockedRegions, sendMessage, MESSAGE_TYPES);
-            });
-        } else {
-            startObserver(memoizedIsEnabledFn, memoizedProcessElementSafe, memoizedScanPageFn, debug);
-            injectSidebarLink(settings, debug, blockedCountries, blockedRegions, sendMessage, MESSAGE_TYPES);
-        }
+        injectSidebarLink(settings, debug, blockedCountries, blockedRegions, sendMessage, MESSAGE_TYPES);
 
     } catch (error) {
         console.error('X-Posed initialization failed:', error);

--- a/extension/src/content/content-script.js
+++ b/extension/src/content/content-script.js
@@ -61,6 +61,36 @@ function debug(...args) {
     }
 }
 
+function fetchUserInfoViaPage(screenName) {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    return new Promise(resolve => {
+        const timeout = setTimeout(() => {
+            window.removeEventListener('x-posed-fetch-user-info-result', onResult);
+            resolve({ success: false, error: 'Timed out waiting for page fetch' });
+        }, 10000);
+
+        function onResult(event) {
+            let result;
+            try {
+                result = JSON.parse(event.detail || '{}');
+            } catch {
+                return;
+            }
+
+            if (result.id !== id) return;
+            clearTimeout(timeout);
+            window.removeEventListener('x-posed-fetch-user-info-result', onResult);
+            resolve(result);
+        }
+
+        window.addEventListener('x-posed-fetch-user-info-result', onResult);
+        window.dispatchEvent(new CustomEvent('x-posed-fetch-user-info', {
+            detail: JSON.stringify({ id, screenName })
+        }));
+    });
+}
+
 // ============================================
 // MESSAGING
 // ============================================
@@ -111,13 +141,24 @@ function injectPageScript() {
  */
 function setupPageScriptListener() {
     window.addEventListener('x-posed-headers-captured', async event => {
-        const { headers } = event.detail;
+        let headers;
+        try {
+            ({ headers } = JSON.parse(event.detail || '{}'));
+        } catch {
+            return;
+        }
+
+        if (!headers) return;
         debug('Headers captured from page script');
         
-        await sendMessage({
+        const response = await sendMessage({
             type: MESSAGE_TYPES.CAPTURE_HEADERS,
             payload: { headers }
         });
+
+        if (response?.success && memoizedScanPageFn) {
+            setTimeout(() => memoizedScanPageFn(), 250);
+        }
     });
 }
 
@@ -246,30 +287,41 @@ async function initialize() {
             blockedTags = new Set(blockedTagsResponse.data);
         }
 
-        let domObserverStarted = false;
-        const startDomObservation = () => {
-            if (domObserverStarted || !document.body) return;
-            domObserverStarted = true;
-            createMemoizedFunctions();
-            startObserver(memoizedIsEnabledFn, memoizedProcessElementSafe, memoizedScanPageFn, debug);
-        };
-
-        // Start core DOM processing before optional UI setup. This keeps badge
-        // injection working even if theme/sidebar setup hits a page-specific edge.
-        startDomObservation();
-        if (!domObserverStarted) {
-            document.addEventListener('DOMContentLoaded', startDomObservation, { once: true });
-        }
+        createMemoizedFunctions();
 
         // Inject styles
         injectStyles();
 
-        // Detect and apply theme
-        detectAndApplyTheme(debug);
-        startThemeObserver();
+        let readyWorkStarted = false;
+        const startReadyWork = () => {
+            if (readyWorkStarted) return;
+            if (!document.body) {
+                setTimeout(startReadyWork, 100);
+                return;
+            }
 
-        injectSidebarLink(settings, debug, blockedCountries, blockedRegions, sendMessage, MESSAGE_TYPES);
+            readyWorkStarted = true;
+            startObserver(memoizedIsEnabledFn, memoizedProcessElementSafe, memoizedScanPageFn, debug);
 
+            try {
+                detectAndApplyTheme(debug);
+                startThemeObserver();
+            } catch (error) {
+                console.error('X-Posed theme failed:', error);
+            }
+
+            try {
+                injectSidebarLink(settings, debug, blockedCountries, blockedRegions, sendMessage, MESSAGE_TYPES);
+            } catch (error) {
+                console.error('X-Posed sidebar failed:', error);
+            }
+        };
+
+        if (document.readyState !== 'loading') {
+            startReadyWork();
+        } else {
+            document.addEventListener('DOMContentLoaded', startReadyWork, { once: true });
+        }
     } catch (error) {
         console.error('X-Posed initialization failed:', error);
     }
@@ -296,6 +348,7 @@ function createMemoizedFunctions() {
         get settings() { return settings; },
         get csrfToken() { return csrfToken; },
         sendMessage,
+        fetchUserInfoViaPage,
         debug,
         get debugMode() { return debugMode; }
     });

--- a/extension/src/content/hovercard.js
+++ b/extension/src/content/hovercard.js
@@ -355,7 +355,7 @@ class HovercardController {
         positionCard(this.card, anchorEl);
 
         // Fetch rich metadata ONLY on hover (forces API), with short TTL caching.
-        this._fetchAndUpdate(anchorEl, screenName, csrfToken).catch(() => {});
+        this._fetchAndUpdate(anchorEl, screenName, csrfToken, info).catch(() => {});
 
         // Keep visible if hovering card
         this.card.removeEventListener('mouseenter', this._handleCardEnter);
@@ -400,7 +400,7 @@ class HovercardController {
         this.hideSoon(120);
     }
 
-    async _fetchAndUpdate(anchorEl, screenName, csrfToken) {
+    async _fetchAndUpdate(anchorEl, screenName, csrfToken, initialInfo = {}) {
         const key = String(screenName || '').toLowerCase();
         if (!key) return;
 
@@ -431,7 +431,7 @@ class HovercardController {
         if (!response?.success || !response.data) {
             const msg = response?.error || 'Failed to fetch details';
             if (this.currentAnchor === anchorEl && this.card?.classList.contains('x-posed-hovercard-visible')) {
-                this.card = buildCardContent({ screenName, info: {}, loading: false, errorText: msg });
+                this.card = buildCardContent({ screenName, info: initialInfo, loading: false, errorText: msg });
                 this.card.classList.add('x-posed-hovercard-visible');
                 positionCard(this.card, anchorEl);
             }

--- a/extension/src/content/observer.js
+++ b/extension/src/content/observer.js
@@ -442,6 +442,7 @@ export async function processElement(element, {
     settings,
     csrfToken,
     sendMessage,
+    fetchUserInfoViaPage,
     debug,
     debugMode
 }) {
@@ -671,10 +672,21 @@ export async function processElement(element, {
     }
 
     try {
-        const response = await sendMessage({
+        let response = await sendMessage({
             type: MESSAGE_TYPES.FETCH_USER_INFO,
             payload: { screenName, csrfToken }
         });
+
+        if ((response?.code === 'UNAUTHORIZED' || response?.code === 'NO_HEADERS') && fetchUserInfoViaPage) {
+            const pageResponse = await fetchUserInfoViaPage(screenName);
+            if (pageResponse?.success) {
+                response = { ...pageResponse, source: 'page' };
+                await sendMessage({
+                    type: MESSAGE_TYPES.SET_CACHE,
+                    payload: { screenName, data: pageResponse.data }
+                });
+            }
+        }
 
         if (shimmer) shimmer.remove();
 
@@ -710,6 +722,12 @@ export async function processElement(element, {
                 }
             } else if (response?.error) {
                 if (debug) debug(`API error for @${screenName}: ${response.error}`);
+            }
+            if (response?.code === 'UNAUTHORIZED' || response?.code === 'NO_HEADERS') {
+                delete element.dataset.xProcessed;
+                delete element.dataset.xScreenName;
+                processingQueue.delete(screenName);
+                return;
             }
             userInfoCache.set(screenName, null);
             processingQueue.delete(screenName);

--- a/extension/src/content/page-script.js
+++ b/extension/src/content/page-script.js
@@ -15,9 +15,20 @@
     window.__X_POSED_INJECTED__ = true;
 
     const EVENT_HEADERS_CAPTURED = 'x-posed-headers-captured';
+    const EVENT_RESET_HEADERS = 'x-posed-reset-headers';
+    const EVENT_FETCH_USER_INFO = 'x-posed-fetch-user-info';
+    const EVENT_FETCH_USER_INFO_RESULT = 'x-posed-fetch-user-info-result';
     const API_PATTERN = /x\.com\/i\/api\/graphql/;
+    const ABOUT_QUERY_ID = 'XRqGa7EeokUU5kppkh13EA';
 
     let headersCaptured = false;
+    let capturedHeaders = null;
+
+    function hasHeader(headers, name) {
+        if (headers instanceof Headers) return headers.has(name);
+        const wanted = name.toLowerCase();
+        return Object.keys(headers || {}).some(key => key.toLowerCase() === wanted);
+    }
 
     /**
      * Send captured headers to content script
@@ -25,8 +36,7 @@
     function sendHeaders(headers) {
         if (headersCaptured) return;
         
-        // Validate we have auth headers
-        if (!headers || (!headers.authorization && !headers['authorization'])) {
+        if (!hasHeader(headers, 'authorization') || !hasHeader(headers, 'x-csrf-token')) {
             return;
         }
 
@@ -36,14 +46,92 @@
         const headerObj = headers instanceof Headers 
             ? Object.fromEntries(headers.entries()) 
             : { ...headers };
+        capturedHeaders = headerObj;
 
         // Dispatch custom event for content script
         window.dispatchEvent(new CustomEvent(EVENT_HEADERS_CAPTURED, {
-            detail: { headers: headerObj }
+            detail: JSON.stringify({ headers: headerObj })
         }));
 
         console.log('✅ X-Posed: API headers captured');
     }
+
+    window.addEventListener(EVENT_RESET_HEADERS, () => {
+        headersCaptured = false;
+        capturedHeaders = null;
+        console.log('🔄 X-Posed: Headers reset - waiting for next API request');
+    });
+
+    function parseAboutAccount(data) {
+        const user = data?.data?.user_result_by_screen_name?.result;
+        const profile = user?.about_profile;
+
+        return {
+            location: profile?.account_based_in || null,
+            device: profile?.source || null,
+            locationAccurate: profile?.location_accurate !== false,
+            meta: {
+                name: user?.core?.name || null,
+                avatarUrl: user?.avatar?.image_url || null,
+                createdAt: user?.core?.created_at || null,
+                restId: user?.rest_id || null
+            }
+        };
+    }
+
+    window.addEventListener(EVENT_FETCH_USER_INFO, async event => {
+        let request = {};
+        try {
+            request = JSON.parse(event.detail || '{}');
+        } catch {
+            request = {};
+        }
+
+        const { id, screenName } = request;
+
+        try {
+            if (!id || !screenName || !capturedHeaders) {
+                throw new Error('No captured page headers available');
+            }
+
+            const variables = encodeURIComponent(JSON.stringify({ screenName }));
+            const url = `/i/api/graphql/${ABOUT_QUERY_ID}/AboutAccountQuery?variables=${variables}`;
+            const response = await fetch(url, {
+                headers: {
+                    ...capturedHeaders,
+                    'accept-language': 'en-US,en;q=0.9'
+                },
+                method: 'GET',
+                credentials: 'include'
+            });
+
+            if (!response.ok) {
+                if (response.status === 401 || response.status === 403) {
+                    headersCaptured = false;
+                    capturedHeaders = null;
+                    window.dispatchEvent(new CustomEvent(EVENT_FETCH_USER_INFO_RESULT, {
+                        detail: JSON.stringify({
+                            id,
+                            success: false,
+                            error: 'Authentication failed',
+                            code: 'UNAUTHORIZED'
+                        })
+                    }));
+                    return;
+                }
+
+                throw new Error(`Page API error: ${response.status}`);
+            }
+
+            window.dispatchEvent(new CustomEvent(EVENT_FETCH_USER_INFO_RESULT, {
+                detail: JSON.stringify({ id, success: true, data: parseAboutAccount(await response.json()) })
+            }));
+        } catch (error) {
+            window.dispatchEvent(new CustomEvent(EVENT_FETCH_USER_INFO_RESULT, {
+                detail: JSON.stringify({ id, success: false, error: error?.message || String(error) })
+            }));
+        }
+    });
 
     /**
      * Safe error logger - only logs in debug scenarios, never throws
@@ -131,8 +219,7 @@
         
         // Force re-capture of headers (useful for debugging)
         resetHeaders: () => {
-            headersCaptured = false;
-            console.log('🔄 X-Posed: Headers reset - waiting for next API request');
+            window.dispatchEvent(new CustomEvent(EVENT_RESET_HEADERS));
         },
         
         // Enable debug mode for error logging


### PR DESCRIPTION
A lot of testing went into this, but I think this fixes several issues about badges and the overlay. 

Fix account lookups in Firefox containers where background requests can fail even after headers are captured. When that happens, the extension now clears stale headers and retries from the page context.

Also makes badge scanning more robust during page startup, so optional theme/sidebar setup errors, extensions like NoScript don't prevent badges from loading. Likely fixes #14 and #18 

